### PR TITLE
fix: correct setup command name in first-run message

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8948,7 +8948,7 @@ async function handleSessionStart() {
   const config = loadConfig();
   if (!config.setup.completed) {
     debugLog("handleSessionStart", "Setup not completed, showing first-run message");
-    console.log(`${ANSI.brick}\u03A8${ANSI.reset} ${ANSI.yellow}First run detected. Run ${ANSI.cyan}/cortex:setup${ANSI.reset} to initialize.`);
+    console.log(`${ANSI.brick}\u03A8${ANSI.reset} ${ANSI.yellow}First run detected. Run ${ANSI.cyan}/cortex-setup${ANSI.reset} to initialize.`);
     return;
   }
   resetAutoSaveState();

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,7 +411,7 @@ async function handleSessionStart() {
   // Check if setup is completed
   if (!config.setup.completed) {
     debugLog('handleSessionStart', 'Setup not completed, showing first-run message');
-    console.log(`${ANSI.brick}Ψ${ANSI.reset} ${ANSI.yellow}First run detected. Run ${ANSI.cyan}/cortex:setup${ANSI.reset} to initialize.`);
+    console.log(`${ANSI.brick}Ψ${ANSI.reset} ${ANSI.yellow}First run detected. Run ${ANSI.cyan}/cortex-setup${ANSI.reset} to initialize.`);
     return;
   }
 


### PR DESCRIPTION
## Summary
- The first-run message incorrectly instructed users to run `/cortex:setup` but the actual skill command is `/cortex-setup` (with a hyphen, not a colon)
- This caused confusion for new users who couldn't find the command

## Changes
- Fixed the command name in `src/index.ts` line 414
- Rebuilt `dist/index.js`

## Test
After this fix, the first-run message will display:
```
Ψ First run detected. Run /cortex-setup to initialize.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)